### PR TITLE
Fix NullPointerException error with receipt.getTransactionAmount()

### DIFF
--- a/library/src/main/java/com/heartlandpaymentsystems/library/terminals/c2x/C2XDevice.java
+++ b/library/src/main/java/com/heartlandpaymentsystems/library/terminals/c2x/C2XDevice.java
@@ -206,7 +206,9 @@ public class C2XDevice implements IDevice {
         terminalConfig.setOutputCapability(TerminalOutputCapability.PRINT_AND_DISPLAY);
         terminalConfig.setAuthenticationCapability(TerminalAuthenticationCapability.NO_CAPABILITY);
         terminalConfig.setOperatingEnvironment(TerminalOperatingEnvironment.ON_MERCHANT_PREMISES_ATTENDED);
-        terminalConfig.setTimeout(Long.getLong(connectionConfig.getTimeout()));
+
+        final Long timeout = Long.getLong(connectionConfig.getTimeout());
+        terminalConfig.setTimeout(timeout != null ? timeout : 60000L);
 
         HashMap<String, String> credentials = new HashMap<>();
 //        credentials.put("secret_api_key", connectionConfig.getSecretApiKey());

--- a/library/src/main/java/com/heartlandpaymentsystems/library/terminals/entities/TerminalResponse.java
+++ b/library/src/main/java/com/heartlandpaymentsystems/library/terminals/entities/TerminalResponse.java
@@ -120,7 +120,9 @@ public class TerminalResponse implements IDeviceResponse {
 //            receipt.getTerminalCountryCode();
 //            receipt.getTerminalType();
             response.setTerminalVerificationResult(receipt.getTerminalVerificationResult());
-            response.setTransactionAmount((new BigDecimal(receipt.getTransactionAmount())).movePointLeft(2));
+            if (receipt.getTransactionAmount() != null) {
+                response.setTransactionAmount((new BigDecimal(receipt.getTransactionAmount())).movePointLeft(2));
+            }
 //            receipt.getTransactionDateTime();
             response.setTransactionId(receipt.getTransactionId());
             if (receipt.getTransactionType() != null) {


### PR DESCRIPTION
Encountering a crash. I believe receipt.getTransactionAmount() can be left uninitialized causing the null exception error.